### PR TITLE
Fixed detekt configuration to work in windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,14 @@ dependencies {
 
 detekt {
     config = files("detekt-config.yml")
-    input = files("$projectDir")
+    input = files(
+            "$projectDir/app",
+            "$projectDir/fountain-core",
+            "$projectDir/fountain-coroutines",
+            "$projectDir/fountain-retrofit",
+            "$projectDir/fountain-rx2",
+            "$projectDir/fountain-testutils"
+    )
     filters = ".*/resources/.*,.*/build/.*"
 }
 


### PR DESCRIPTION
Fixed detekt configuration to work in windows: 

### Related issue:
https://stackoverflow.com/questions/48632019/gradle-build-error-on-windows-failed-to-create-md5-hash-for-file